### PR TITLE
Global session 이용을 위한 Redis 환경설정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,9 +28,9 @@ dependencies {
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
-    //sqllite
+    //sql-lite
     implementation 'org.xerial:sqlite-jdbc:3.43.2.2'
-    implementation("org.hibernate.orm:hibernate-community-dialects:6.1.6.Final")
+    implementation('org.hibernate.orm:hibernate-community-dialects:6.1.7.Final')
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -31,6 +31,9 @@ dependencies {
     //sql-lite
     implementation 'org.xerial:sqlite-jdbc:3.43.2.2'
     implementation('org.hibernate.orm:hibernate-community-dialects:6.1.7.Final')
+    //redis
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+    implementation 'org.springframework.session:spring-session-data-redis'
 }
 
 tasks.named('test') {

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -1,7 +1,24 @@
+server:
+  port: 8080
+  servlet:
+    session:
+      cookie:
+        path: /
+        name: JSESSIONID
+        http-only: true
+      timeout: 3600
+
 spring:
   datasource:
     driver-class-name: org.sqlite.JDBC
     url: jdbc:sqlite:sqlite-sample.db
+  redis:
+    host: localhost
+    port: 6379
+  session:
+    store-type: redis
+    redis:
+      namespace: spring:session
   jpa:
     properties:
       hibernate:


### PR DESCRIPTION
## 🔑 Key Changes
- Global session 이용을 위한 Redis 환경설정을 하였습니다.
  - `build.gradle` session, redis 의존성 추가하였습니다.
  - `application-local.yml` 에 session 사용환경 설정을 추가하였습니다.

## 👩‍💻 To Reviewers
- 

## Related to
Closed #17 
