### PR TITLE
Member API 일부 구현 - 로그인, 로그아웃 (미완성)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,15 +25,20 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    // webflux
+    implementation 'org.springframework.boot:spring-boot-starter-webflux'
+    // lombok
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
-    //sql-lite
+    // sql-lite
     implementation 'org.xerial:sqlite-jdbc:3.43.2.2'
     implementation('org.hibernate.orm:hibernate-community-dialects:6.1.7.Final')
     //redis
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     implementation 'org.springframework.session:spring-session-data-redis'
+    // MySQL
+    runtimeOnly 'com.mysql:mysql-connector-j'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/flytrap/rssreader/config/PropertiesScanConfig.java
+++ b/src/main/java/com/flytrap/rssreader/config/PropertiesScanConfig.java
@@ -1,0 +1,9 @@
+package com.flytrap.rssreader.config;
+
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@ConfigurationPropertiesScan("com.flytrap.rssreader.infrastructure.properties")
+public class PropertiesScanConfig {
+}

--- a/src/main/java/com/flytrap/rssreader/config/WebClientConfig.java
+++ b/src/main/java/com/flytrap/rssreader/config/WebClientConfig.java
@@ -1,0 +1,91 @@
+package com.flytrap.rssreader.config;
+
+import com.flytrap.rssreader.infrastructure.properties.OauthProperties;
+import io.netty.channel.ChannelOption;
+import io.netty.handler.timeout.ReadTimeoutHandler;
+import io.netty.handler.timeout.WriteTimeoutHandler;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.client.reactive.ReactorClientHttpConnector;
+import org.springframework.http.codec.LoggingCodecSupport;
+import org.springframework.web.reactive.function.client.ExchangeFilterFunction;
+import org.springframework.web.reactive.function.client.ExchangeStrategies;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+import reactor.netty.http.client.HttpClient;
+
+@Slf4j
+@Configuration
+@RequiredArgsConstructor
+public class WebClientConfig {
+
+    private final OauthProperties oauthProperties;
+
+    @Bean(name = "githubAuthorizationServer")
+    public WebClient githubAuthorizationServerWebClient() {
+        return buildWebClient(oauthProperties.github().accessTokenUri());
+    }
+
+    @Bean(name = "githubResourceServer")
+    public WebClient githubResourceServerWebClient() {
+        return buildWebClient(oauthProperties.github().userResourceUri());
+    }
+
+    /**
+     * WebClient 요청시 log 출력합니다.
+     * @return ExchangeFilterFunction
+     */
+    private ExchangeFilterFunction logRequest() {
+        return ExchangeFilterFunction.ofRequestProcessor(clientRequest -> {
+            log.debug("{} Request: {} {}", clientRequest.url(), clientRequest.method(), clientRequest.url());
+            clientRequest.headers().forEach((name, values) -> values.forEach(value -> log.debug("{} : {}", name, value)));
+            return Mono.just(clientRequest);
+        });
+    }
+
+    /**
+     * WebClient 반환시 log 출력합니다.
+     * @return ExchangeFilterFunction
+     */
+    private ExchangeFilterFunction logResponse() {
+        return ExchangeFilterFunction.ofResponseProcessor(clientResponse -> {
+            clientResponse.headers().asHttpHeaders().forEach((name, values) -> values.forEach(value -> log.debug("{} : {}", name, value)));
+            return Mono.just(clientResponse);
+        });
+    }
+
+    /**
+     * Base url로 요청을 보내는 WebClient를 반환합니다.
+     * @param baseUrl
+     * @return WebClient
+     */
+    private WebClient buildWebClient(String baseUrl) {
+        ExchangeStrategies exchangeStrategies = ExchangeStrategies.builder()
+            .codecs(configurer -> configurer.defaultCodecs().maxInMemorySize(1024*1024*50))
+            .build();
+        exchangeStrategies
+            .messageWriters().stream()
+            .filter(LoggingCodecSupport.class::isInstance)
+            .forEach(writer -> ((LoggingCodecSupport)writer).setEnableLoggingRequestDetails(true));
+
+        return WebClient.builder()
+            .baseUrl(baseUrl)
+            .clientConnector(
+                new ReactorClientHttpConnector(
+                    HttpClient
+                        .create()
+                        .option(
+                            ChannelOption.CONNECT_TIMEOUT_MILLIS, 120_000)
+                        .doOnConnected(conn -> conn.addHandlerLast(new ReadTimeoutHandler(180))
+                            .addHandlerLast(new WriteTimeoutHandler(180))
+                        )
+                )
+            )
+            .exchangeStrategies(exchangeStrategies)
+            .filter(logRequest())
+            .filter(logResponse())
+            .build();
+    }
+}

--- a/src/main/java/com/flytrap/rssreader/domain/member/Member.java
+++ b/src/main/java/com/flytrap/rssreader/domain/member/Member.java
@@ -1,0 +1,59 @@
+package com.flytrap.rssreader.domain.member;
+
+import com.flytrap.rssreader.infrastructure.entity.member.OauthServer;
+import java.time.Instant;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Member {
+
+    private Long id;
+    private String name;
+    private String email;
+    private String profile;
+    private OauthInfo oauthInfo;
+    private Instant createdAt;
+
+    @Builder
+    private Member(Long id, String name, String email, String profile, long oauthPk, OauthServer oauthServer,
+        Instant createdAt) {
+        this.id = id;
+        this.name = name;
+        this.email = email;
+        this.profile = profile;
+        this.oauthInfo = new OauthInfo(oauthPk, oauthServer);
+        this.createdAt = createdAt;
+    }
+
+    public static Member of(Long id, String name, String email, String profile, Long oauthPk, OauthServer oauthServer, Instant createdAt) {
+        return Member.builder()
+            .id(id)
+            .name(name)
+            .email(email)
+            .profile(profile)
+            .oauthPk(oauthPk)
+            .oauthServer(oauthServer)
+            .createdAt(createdAt)
+            .build();
+    }
+
+    public Long getOauthPk() {
+        return this.oauthInfo.getOauthPk();
+    }
+
+    public OauthServer getOauthServer() {
+        return this.oauthInfo.getOauthServer();
+    }
+}
+
+@Getter
+@AllArgsConstructor
+class OauthInfo {
+    private Long oauthPk;
+    private OauthServer oauthServer;
+}

--- a/src/main/java/com/flytrap/rssreader/global/model/ApplicationResponse.java
+++ b/src/main/java/com/flytrap/rssreader/global/model/ApplicationResponse.java
@@ -1,0 +1,8 @@
+package com.flytrap.rssreader.global.model;
+
+import lombok.AllArgsConstructor;
+
+@AllArgsConstructor
+public class ApplicationResponse<T> {
+     T data;
+}

--- a/src/main/java/com/flytrap/rssreader/infrastructure/api/AuthGithubProvider.java
+++ b/src/main/java/com/flytrap/rssreader/infrastructure/api/AuthGithubProvider.java
@@ -1,0 +1,56 @@
+package com.flytrap.rssreader.infrastructure.api;
+
+import com.flytrap.rssreader.infrastructure.api.dto.AccessToken;
+import com.flytrap.rssreader.infrastructure.api.dto.UserResource;
+import com.flytrap.rssreader.infrastructure.properties.OauthProperties;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.reactive.function.BodyInserters;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+
+@Component
+public record AuthGithubProvider(WebClient githubAuthorizationServer,
+                                 WebClient githubResourceServer,
+                                 OauthProperties oauthProperties) implements AuthProvider {
+
+    @Override
+    public Mono<AccessToken> requestAccessToken(String code) {
+        MultiValueMap<String, String> formData = new LinkedMultiValueMap<>();
+        formData.add("code", code);
+        formData.add("client_id", oauthProperties.github().clientId());
+        formData.add("client_secret", oauthProperties.github().clientSecret());
+        formData.add("redirect_uri", oauthProperties.github().redirectUri());
+
+        return githubAuthorizationServer
+            .post()
+            .accept(MediaType.APPLICATION_JSON)
+            .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+            .body(BodyInserters.fromFormData(formData))
+            .retrieve()
+            .onStatus(status -> status.is4xxClientError()
+                    || status.is5xxServerError()
+                , clientResponse ->
+                    clientResponse.bodyToMono(String.class)
+                        .map(body -> new Exception("exception"))) // TODO 외부 API 오류시 처리
+            .bodyToMono(AccessToken.class);
+    }
+
+    @Override
+    public Mono<UserResource> requestUserResource(AccessToken accessToken) {
+        return githubResourceServer
+            .get()
+            .header(HttpHeaders.AUTHORIZATION, accessToken.getHeadValue())
+            .accept(MediaType.APPLICATION_JSON)
+            .retrieve()
+            .onStatus(status -> status.is4xxClientError()
+                    || status.is5xxServerError()
+                , clientResponse ->
+                    clientResponse.bodyToMono(String.class)
+                        .map(body -> new Exception("exception"))) // TODO 외부 API 오류시 처리
+            .bodyToMono(UserResource.class);
+    }
+}

--- a/src/main/java/com/flytrap/rssreader/infrastructure/api/AuthProvider.java
+++ b/src/main/java/com/flytrap/rssreader/infrastructure/api/AuthProvider.java
@@ -1,0 +1,23 @@
+package com.flytrap.rssreader.infrastructure.api;
+
+import com.flytrap.rssreader.infrastructure.api.dto.AccessToken;
+import com.flytrap.rssreader.infrastructure.api.dto.UserResource;
+import reactor.core.publisher.Mono;
+
+public interface AuthProvider {
+
+    /**
+     * Oauth 인증 서버에 인증 코드를 보내고 Access Token을 발급받습니다.
+     * @param code
+     * @return AccessToken
+     */
+    Mono<AccessToken> requestAccessToken(String code);
+
+    /**
+     * Oauth 사용자 Resource 서버에 Access token을 보내고 사용자 Resource를 반환받습니다.
+     * @param accessToken
+     * @return UserResource
+     */
+    Mono<UserResource> requestUserResource(AccessToken accessToken);
+
+}

--- a/src/main/java/com/flytrap/rssreader/infrastructure/api/dto/AccessToken.java
+++ b/src/main/java/com/flytrap/rssreader/infrastructure/api/dto/AccessToken.java
@@ -1,0 +1,11 @@
+package com.flytrap.rssreader.infrastructure.api.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record AccessToken(@JsonProperty("access_token") String accessToken,
+                          @JsonProperty("token_type") String tokenType) {
+
+    public String getHeadValue() {
+        return String.format("%s %s", accessToken, tokenType);
+    }
+}

--- a/src/main/java/com/flytrap/rssreader/infrastructure/api/dto/UserResource.java
+++ b/src/main/java/com/flytrap/rssreader/infrastructure/api/dto/UserResource.java
@@ -1,0 +1,16 @@
+package com.flytrap.rssreader.infrastructure.api.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.flytrap.rssreader.domain.member.Member;
+import com.flytrap.rssreader.infrastructure.entity.member.OauthServer;
+
+public record UserResource(Long id,
+                           String email,
+                           String login,
+                           @JsonProperty("avatar_url") String avatarUrl) {
+
+    public Member toDomainForCreate() {
+        return Member.of(null, login, email, avatarUrl, id, OauthServer.GITHUB, null);
+    }
+
+}

--- a/src/main/java/com/flytrap/rssreader/infrastructure/entity/member/MemberEntity.java
+++ b/src/main/java/com/flytrap/rssreader/infrastructure/entity/member/MemberEntity.java
@@ -1,0 +1,75 @@
+package com.flytrap.rssreader.infrastructure.entity.member;
+
+import com.flytrap.rssreader.domain.member.Member;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.time.Instant;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@Entity
+@Table(name = "member")
+@EntityListeners(AuditingEntityListener.class)
+public class MemberEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(length = 255, nullable = false)
+    private String name;
+
+    @Column(length = 255, nullable = false)
+    private String email;
+
+    @Column(length = 2500, nullable = false)
+    private String profile;
+
+    @Column(unique = true, nullable = false)
+    private Long oauthPk;
+
+    @Enumerated(EnumType.STRING)
+    private OauthServer oauthServer;
+
+    @CreatedDate
+    private Instant createdAt;
+
+    @Builder
+    protected MemberEntity(Long id, String name, String email, String profile, Long oauthPk,
+        OauthServer oauthServer) {
+        this.id = id;
+        this.name = name;
+        this.email = email;
+        this.profile = profile;
+        this.oauthPk = oauthPk;
+        this.oauthServer = oauthServer;
+    }
+
+    public Member toDomain() {
+        return Member.of(this.id, this.name, this.email, this.profile, this.oauthPk, this.oauthServer, this.createdAt);
+    }
+
+    public static MemberEntity from(Member member) {
+        return MemberEntity.builder()
+            .id(member.getId())
+            .name(member.getName())
+            .email(member.getEmail())
+            .profile(member.getProfile())
+            .oauthPk(member.getOauthPk())
+            .oauthServer(member.getOauthServer())
+            .build();
+    }
+}

--- a/src/main/java/com/flytrap/rssreader/infrastructure/entity/member/OauthServer.java
+++ b/src/main/java/com/flytrap/rssreader/infrastructure/entity/member/OauthServer.java
@@ -1,0 +1,5 @@
+package com.flytrap.rssreader.infrastructure.entity.member;
+
+public enum OauthServer {
+    GITHUB;
+}

--- a/src/main/java/com/flytrap/rssreader/infrastructure/properties/OauthProperties.java
+++ b/src/main/java/com/flytrap/rssreader/infrastructure/properties/OauthProperties.java
@@ -1,0 +1,11 @@
+package com.flytrap.rssreader.infrastructure.properties;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "oauth")
+public record OauthProperties(Github github) {
+
+    public record Github(String clientId, String clientSecret, String userResourceUri
+        ,String accessTokenUri, String redirectUri) {
+    }
+}

--- a/src/main/java/com/flytrap/rssreader/infrastructure/repository/MemberEntityJpaRepository.java
+++ b/src/main/java/com/flytrap/rssreader/infrastructure/repository/MemberEntityJpaRepository.java
@@ -1,0 +1,9 @@
+package com.flytrap.rssreader.infrastructure.repository;
+
+import com.flytrap.rssreader.infrastructure.entity.member.MemberEntity;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MemberEntityJpaRepository extends JpaRepository<MemberEntity, Long> {
+    Optional<MemberEntity> findByOauthPk(long oauthPk);
+}

--- a/src/main/java/com/flytrap/rssreader/presentation/controller/AuthController.java
+++ b/src/main/java/com/flytrap/rssreader/presentation/controller/AuthController.java
@@ -1,0 +1,39 @@
+package com.flytrap.rssreader.presentation.controller;
+
+import com.flytrap.rssreader.domain.member.Member;
+import com.flytrap.rssreader.global.model.ApplicationResponse;
+import com.flytrap.rssreader.presentation.dto.Login;
+import com.flytrap.rssreader.service.AuthService;
+import jakarta.servlet.http.HttpSession;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/auth")
+public class AuthController {
+
+    private final AuthService authService;
+
+    @PostMapping("/login")
+    public ApplicationResponse<Member> login(Login.Request request, HttpSession session) {
+
+        Member member = authService.doAuthentication(request);
+        authService.login(member, session);
+
+        return new ApplicationResponse<>(member); // TODO DTO만들어서 반환
+    }
+
+    @PostMapping("/logout")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public ApplicationResponse<Void> logout(HttpSession session) {
+
+        authService.logout(session);
+
+        return new ApplicationResponse<>(null); // DTO 반환
+    }
+}

--- a/src/main/java/com/flytrap/rssreader/presentation/controller/MemberController.java
+++ b/src/main/java/com/flytrap/rssreader/presentation/controller/MemberController.java
@@ -1,0 +1,18 @@
+package com.flytrap.rssreader.presentation.controller;
+
+import com.flytrap.rssreader.global.model.ApplicationResponse;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/members")
+public class MemberController {
+
+    @GetMapping
+    public ApplicationResponse<Object> searchMemberByName(String name) {
+
+        return new ApplicationResponse<>(null);
+    }
+
+}

--- a/src/main/java/com/flytrap/rssreader/presentation/dto/Login.java
+++ b/src/main/java/com/flytrap/rssreader/presentation/dto/Login.java
@@ -1,0 +1,9 @@
+package com.flytrap.rssreader.presentation.dto;
+
+import lombok.Getter;
+
+public record Login(Request request) {
+
+    public record Request (String code) {}
+
+}

--- a/src/main/java/com/flytrap/rssreader/service/AuthService.java
+++ b/src/main/java/com/flytrap/rssreader/service/AuthService.java
@@ -1,0 +1,33 @@
+package com.flytrap.rssreader.service;
+
+import com.flytrap.rssreader.domain.member.Member;
+import com.flytrap.rssreader.infrastructure.api.AuthProvider;
+import com.flytrap.rssreader.presentation.dto.Login;
+import jakarta.servlet.http.HttpSession;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class AuthService {
+
+    private static final String SESSION_KEY = "login_session::";
+
+    private final AuthProvider authProvider;
+    private final MemberService memberService;
+
+    public Member doAuthentication(Login.Request request) {
+        return authProvider.requestAccessToken(request.code())
+            .flatMap(authProvider::requestUserResource)
+            .map(memberService::loginMember)
+            .block();
+    }
+
+    public void login(Member member, HttpSession session) {
+        session.setAttribute(SESSION_KEY, member);
+    }
+
+    public void logout(HttpSession session) {
+        session.removeAttribute(SESSION_KEY);
+    }
+}

--- a/src/main/java/com/flytrap/rssreader/service/MemberService.java
+++ b/src/main/java/com/flytrap/rssreader/service/MemberService.java
@@ -1,0 +1,33 @@
+package com.flytrap.rssreader.service;
+
+import com.flytrap.rssreader.domain.member.Member;
+import com.flytrap.rssreader.infrastructure.api.dto.UserResource;
+import com.flytrap.rssreader.infrastructure.entity.member.MemberEntity;
+import com.flytrap.rssreader.infrastructure.repository.MemberEntityJpaRepository;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class MemberService {
+
+    private final MemberEntityJpaRepository memberEntityJpaRepository;
+
+    /**
+     * User resource가 Member 테이블에 존재하지 않으면 새로 가입 후 Member 정보를 반환합니다.
+     * @param userResource
+     * @return
+     */
+    @Transactional
+    public Member loginMember(UserResource userResource) {
+
+        return memberEntityJpaRepository.findByOauthPk(userResource.id())
+            .orElseGet(() -> joinMember(userResource.toDomainForCreate()))
+            .toDomain();
+    }
+
+    private MemberEntity joinMember(Member member) {
+        return memberEntityJpaRepository.save(MemberEntity.from(member));
+    }
+}

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -10,11 +10,10 @@ server:
 
 spring:
   datasource:
-    driver-class-name: org.sqlite.JDBC
-    url: jdbc:sqlite:sqlite-sample.db
-  redis:
-    host: localhost
-    port: 6379
+    url: jdbc:mysql://localhost:3306/rss_reader
+    username: root
+    password: qwer1234
+    driver-class-name: com.mysql.cj.jdbc.Driver
   session:
     store-type: redis
     redis:
@@ -25,4 +24,8 @@ spring:
         format_sql: true
     show-sql: true
     hibernate:
-      ddl-auto: create
+      # ddl-auto: create
+  data:
+    redis:
+      host: localhost
+      port: 6379

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -2,4 +2,4 @@ spring:
   profiles:
     active: local
     group:
-        local: [ local ] # localhost
+        local: [ local, oauth ] # localhost

--- a/src/main/resources/db/schema.sql
+++ b/src/main/resources/db/schema.sql
@@ -1,0 +1,11 @@
+CREATE SCHEMA IF NOT EXISTS 'rss_reader';
+
+CREATE TABLE IF NOT EXISTS `member` (
+    `id`	bigint	NOT NULL PRIMARY KEY AUTO_INCREMENT,
+    `name`	varchar(255)	NOT NULL,
+    `email`	varchar(255)	NOT NULL,
+    `profile`	varchar(2500)	NOT NULL,
+    `oauth_pk`	bigint	NOT NULL,
+    `oauth_server`	enum('GITHUB')	NOT NULL,
+    `created_at`	date	NOT NULL
+);

--- a/src/test/java/com/flytrap/rssreader/service/AuthServiceTest.java
+++ b/src/test/java/com/flytrap/rssreader/service/AuthServiceTest.java
@@ -1,0 +1,96 @@
+package com.flytrap.rssreader.service;
+
+import static org.mockito.BDDMockito.*;
+
+import com.flytrap.rssreader.domain.member.Member;
+import com.flytrap.rssreader.infrastructure.api.AuthProvider;
+import com.flytrap.rssreader.infrastructure.api.dto.AccessToken;
+import com.flytrap.rssreader.infrastructure.api.dto.UserResource;
+import com.flytrap.rssreader.infrastructure.entity.member.OauthServer;
+import com.flytrap.rssreader.presentation.dto.Login.Request;
+import jakarta.servlet.http.HttpSession;
+import org.assertj.core.api.SoftAssertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import reactor.core.publisher.Mono;
+
+@DisplayName("Auth 서비스 로직 -Auth")
+@ExtendWith(MockitoExtension.class)
+class AuthServiceTest {
+
+    @Mock
+    AuthProvider authProvider;
+
+    @Mock
+    MemberService memberService;
+
+    @Mock
+    HttpSession session;
+
+    @InjectMocks
+    AuthService authService;
+
+    @BeforeEach
+    void init() {
+        when(authProvider.requestAccessToken(anyString()))
+            .thenReturn(Mono.just(new AccessToken("test_access_token", "Bearer")));
+        when(authProvider.requestUserResource(any()))
+            .thenReturn(Mono.just(new UserResource(1L, "test@gmail.com", "login", "img.jpg")));
+        when(memberService.loginMember(any()))
+            .thenReturn(
+                Member.builder()
+                    .id(1L)
+                    .name("테스트")
+                    .email("test@gmail.com")
+                    .profile("img.jpg")
+                    .oauthPk(11L)
+                    .oauthServer(OauthServer.GITHUB)
+                    .build()
+            );
+    }
+
+    @Test
+    @DisplayName("클라이언트가 oauth 인증 서버로부터 받은 코드를 통해 회원가입하거나 로그인할 수 있다.")
+    void doAuthentication() {
+        // when
+        Member member = authService.doAuthentication(new Request("code"));
+
+        // then
+        SoftAssertions.assertSoftly(softAssertions -> {
+            softAssertions.assertThat(member.getId()).isEqualTo(1);
+            softAssertions.assertThat(member.getEmail()).isEqualTo("test@gmail.com");
+            softAssertions.assertThat(member.getProfile()).isEqualTo("img.jpg");
+        });
+    }
+
+    @Test
+    @DisplayName("클라이언트가 oauth 인증 서버로부터 받은 코드를 통해 세션에 member를 저장된다.")
+    void login() {
+        //given
+        Member member = authService.doAuthentication(new Request("code"));
+
+        //when
+        authService.login(member, session);
+
+        //then
+        verify(session, times(1)).setAttribute("login_session::", member);
+    }
+
+    @Test
+    @DisplayName("클라이언트가 oauth 인증 서버로부터 받은 코드를 통해 세션에 member를 삭제된다.")
+    void logout() {
+        //given
+        Member member = authService.doAuthentication(new Request("code"));
+
+        //when
+        authService.logout(session);
+
+        //then
+        verify(session, times(1)).removeAttribute("login_session::");
+    }
+}

--- a/src/test/java/com/flytrap/rssreader/service/MemberServiceTest.java
+++ b/src/test/java/com/flytrap/rssreader/service/MemberServiceTest.java
@@ -1,0 +1,93 @@
+package com.flytrap.rssreader.service;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+
+import com.flytrap.rssreader.domain.member.Member;
+import com.flytrap.rssreader.infrastructure.api.dto.UserResource;
+import com.flytrap.rssreader.infrastructure.entity.member.MemberEntity;
+import com.flytrap.rssreader.infrastructure.entity.member.OauthServer;
+import com.flytrap.rssreader.infrastructure.repository.MemberEntityJpaRepository;
+import java.util.Optional;
+import org.assertj.core.api.SoftAssertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@DisplayName("Member 서비스 로직 -Member")
+@ExtendWith(MockitoExtension.class)
+class MemberServiceTest {
+
+    @Mock
+    MemberEntityJpaRepository memberEntityJpaRepository;
+
+    @InjectMocks
+    MemberService memberService;
+
+    @Test
+    @DisplayName("기존에 존재하는 멤버인 경우 회원을 저장 하지 않고 멤버를 반환한다.")
+    void loginMemberWithExistMember() {
+        // given
+        when(memberEntityJpaRepository.findByOauthPk(1L))
+            .thenReturn(Optional.of(
+                MemberEntity.builder()
+                    .id(1L)
+                    .email("test@gmail.com")
+                    .name("name")
+                    .profile("avatarUrl.jpg")
+                    .oauthPk(1L)
+                    .oauthServer(OauthServer.GITHUB)
+                    .build()
+            ));
+
+        // when
+        Member existMember
+            = memberService.loginMember(
+                new UserResource(1L, "test@gmail.com", "login", "avatarUrl.jpg"));
+
+        // then
+        SoftAssertions.assertSoftly(softAssertions -> {
+            softAssertions.assertThat(existMember.getId()).isEqualTo(1);
+            softAssertions.assertThat(existMember.getEmail()).isEqualTo("test@gmail.com");
+            softAssertions.assertThat(existMember.getProfile()).isEqualTo("avatarUrl.jpg");
+            verify(memberEntityJpaRepository, times(0)).save(any());
+        });
+    }
+
+    @Test
+    @DisplayName("기존에 존재하지 않는 멤버 DB에 저장한 후 멤버를 반환한다.")
+    void loginMemberWithNotExistMember() {
+        //given
+        when(memberEntityJpaRepository.findByOauthPk(1L))
+            .thenReturn(Optional.empty());
+
+        when(memberEntityJpaRepository.save(any()))
+            .thenReturn(
+                MemberEntity.builder()
+                    .id(1L)
+                    .email("test@gmail.com")
+                    .name("name")
+                    .profile("avatarUrl.jpg")
+                    .oauthPk(1L)
+                    .oauthServer(OauthServer.GITHUB)
+                    .build()
+            );
+
+        // when
+        Member newMember
+            = memberService.loginMember(
+            new UserResource(1L, "test@gmail.com", "login", "avatarUrl.jpg"));
+
+        // then
+        SoftAssertions.assertSoftly(softAssertions -> {
+            softAssertions.assertThat(newMember.getId()).isEqualTo(1);
+            softAssertions.assertThat(newMember.getEmail()).isEqualTo("test@gmail.com");
+            softAssertions.assertThat(newMember.getProfile()).isEqualTo("avatarUrl.jpg");
+            verify(memberEntityJpaRepository, times(1)).save(any());
+        });
+    }
+}


### PR DESCRIPTION
## 🔑 Key Changes
- 로그인, 로그아웃, 회원가입 기능과 관련된 Member 도메인 및 controller, service, repository 구현
- Github OAuth 서버와 통신할 WebClient 구현

## 👩‍💻 To Reviewers
- 아직 로그인 시 무엇을 반환할지 정하지 못하고 일단 로그인 시 회원 정보를 session에만 저장하도록 구현해 놓은 상태

## Related to
closes #16 
