### PR TITLE
Member API 변경 후 깨진 Test 수정 (#30)

### DIFF
--- a/src/main/java/com/flytrap/rssreader/presentation/dto/Login.java
+++ b/src/main/java/com/flytrap/rssreader/presentation/dto/Login.java
@@ -1,7 +1,5 @@
 package com.flytrap.rssreader.presentation.dto;
 
-import lombok.Getter;
-
 public record Login(String code) {
 
 }

--- a/src/test/java/com/flytrap/rssreader/service/AuthServiceTest.java
+++ b/src/test/java/com/flytrap/rssreader/service/AuthServiceTest.java
@@ -7,7 +7,7 @@ import com.flytrap.rssreader.infrastructure.api.AuthProvider;
 import com.flytrap.rssreader.infrastructure.api.dto.AccessToken;
 import com.flytrap.rssreader.infrastructure.api.dto.UserResource;
 import com.flytrap.rssreader.infrastructure.entity.member.OauthServer;
-import com.flytrap.rssreader.presentation.dto.Login.Request;
+import com.flytrap.rssreader.presentation.dto.Login;
 import jakarta.servlet.http.HttpSession;
 import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -40,7 +40,7 @@ class AuthServiceTest {
         when(authProvider.requestAccessToken(anyString()))
             .thenReturn(Mono.just(new AccessToken("test_access_token", "Bearer")));
         when(authProvider.requestUserResource(any()))
-            .thenReturn(Mono.just(new UserResource(1L, "test@gmail.com", "login", "img.jpg")));
+            .thenReturn(Mono.just(UserResource.builder().id(1L).email("test@gmail.com").login("login").avatarUrl("img.jpg").build()));
         when(memberService.loginMember(any()))
             .thenReturn(
                 Member.builder()
@@ -58,7 +58,7 @@ class AuthServiceTest {
     @DisplayName("클라이언트가 oauth 인증 서버로부터 받은 코드를 통해 회원가입하거나 로그인할 수 있다.")
     void doAuthentication() {
         // when
-        Member member = authService.doAuthentication(new Request("code"));
+        Member member = authService.doAuthentication(new Login("code"));
 
         // then
         SoftAssertions.assertSoftly(softAssertions -> {
@@ -72,7 +72,7 @@ class AuthServiceTest {
     @DisplayName("클라이언트가 oauth 인증 서버로부터 받은 코드를 통해 세션에 member를 저장된다.")
     void login() {
         //given
-        Member member = authService.doAuthentication(new Request("code"));
+        Member member = authService.doAuthentication(new Login("code"));
 
         //when
         authService.login(member, session);
@@ -85,7 +85,7 @@ class AuthServiceTest {
     @DisplayName("클라이언트가 oauth 인증 서버로부터 받은 코드를 통해 세션에 member를 삭제된다.")
     void logout() {
         //given
-        Member member = authService.doAuthentication(new Request("code"));
+        Member member = authService.doAuthentication(new Login("code"));
 
         //when
         authService.logout(session);

--- a/src/test/java/com/flytrap/rssreader/service/MemberServiceTest.java
+++ b/src/test/java/com/flytrap/rssreader/service/MemberServiceTest.java
@@ -1,6 +1,5 @@
 package com.flytrap.rssreader.service;
 
-import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.BDDMockito.*;
 
 import com.flytrap.rssreader.domain.member.Member;
@@ -10,7 +9,6 @@ import com.flytrap.rssreader.infrastructure.entity.member.OauthServer;
 import com.flytrap.rssreader.infrastructure.repository.MemberEntityJpaRepository;
 import java.util.Optional;
 import org.assertj.core.api.SoftAssertions;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -47,7 +45,12 @@ class MemberServiceTest {
         // when
         Member existMember
             = memberService.loginMember(
-                new UserResource(1L, "test@gmail.com", "login", "avatarUrl.jpg"));
+            UserResource.builder()
+                .id(1L)
+                .email("test@gmail.com")
+                .login("login")
+                .avatarUrl("avatarUrl.jpg")
+                .build());
 
         // then
         SoftAssertions.assertSoftly(softAssertions -> {
@@ -80,7 +83,12 @@ class MemberServiceTest {
         // when
         Member newMember
             = memberService.loginMember(
-            new UserResource(1L, "test@gmail.com", "login", "avatarUrl.jpg"));
+            UserResource.builder()
+                .id(1L)
+                .email("test@gmail.com")
+                .login("login")
+                .avatarUrl("avatarUrl.jpg")
+                .build());
 
         // then
         SoftAssertions.assertSoftly(softAssertions -> {


### PR DESCRIPTION
## 🔑 Key Changes
- Member API 변경 후 깨진 Test 수정
    - UserResource 객체 생성 방식을 builder 패턴으로 변경하면서 기존의 생성자를 사용할 수 없게 되었다. 이에 따라 기존에 사용하던 생성자를 builder로 변경함
    - 기존 Login.Request class를 record로 변경하면서 Request를 제거하고 Login 만 남겨놓게 됨. 기존에 사용하던 Request를 Login으로 변경함
    - 기타 필요없는 import 문 제거

## 👩‍💻 To Reviewers
- 

## Related to
- 
