### PR TITLE
회원 이름으로 검색 구현

### DIFF
--- a/src/main/java/com/flytrap/rssreader/domain/member/Member.java
+++ b/src/main/java/com/flytrap/rssreader/domain/member/Member.java
@@ -2,11 +2,9 @@ package com.flytrap.rssreader.domain.member;
 
 import com.flytrap.rssreader.global.model.DefaultDomain;
 import com.flytrap.rssreader.global.model.Domain;
-import com.flytrap.rssreader.infrastructure.entity.member.OauthServer;
 import java.io.Serializable;
 import java.time.Instant;
 import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -24,8 +22,9 @@ public class Member extends DefaultDomain implements Serializable {
     private Instant createdAt;
 
     @Builder
-    private Member(Long id, String name, String email, String profile, long oauthPk, OauthServer oauthServer,
-        Instant createdAt) {
+    private Member(Long id, String name, String email, String profile, long oauthPk,
+            OauthServer oauthServer,
+            Instant createdAt) {
         this.id = id;
         this.name = name;
         this.email = email;
@@ -34,16 +33,17 @@ public class Member extends DefaultDomain implements Serializable {
         this.createdAt = createdAt;
     }
 
-    public static Member of(Long id, String name, String email, String profile, Long oauthPk, OauthServer oauthServer, Instant createdAt) {
+    public static Member of(Long id, String name, String email, String profile, Long oauthPk,
+            OauthServer oauthServer, Instant createdAt) {
         return Member.builder()
-            .id(id)
-            .name(name)
-            .email(email)
-            .profile(profile)
-            .oauthPk(oauthPk)
-            .oauthServer(oauthServer)
-            .createdAt(createdAt)
-            .build();
+                .id(id)
+                .name(name)
+                .email(email)
+                .profile(profile)
+                .oauthPk(oauthPk)
+                .oauthServer(oauthServer)
+                .createdAt(createdAt)
+                .build();
     }
 
     public Long getOauthPk() {
@@ -53,11 +53,4 @@ public class Member extends DefaultDomain implements Serializable {
     public OauthServer getOauthServer() {
         return this.oauthInfo.getOauthServer();
     }
-}
-
-@Getter
-@AllArgsConstructor
-class OauthInfo implements Serializable {
-    private Long oauthPk;
-    private OauthServer oauthServer;
 }

--- a/src/main/java/com/flytrap/rssreader/domain/member/Member.java
+++ b/src/main/java/com/flytrap/rssreader/domain/member/Member.java
@@ -1,5 +1,7 @@
 package com.flytrap.rssreader.domain.member;
 
+import com.flytrap.rssreader.global.model.DefaultDomain;
+import com.flytrap.rssreader.global.model.Domain;
 import com.flytrap.rssreader.infrastructure.entity.member.OauthServer;
 import java.io.Serializable;
 import java.time.Instant;
@@ -10,8 +12,9 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
+@Domain(name = "member")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Member implements Serializable {
+public class Member extends DefaultDomain implements Serializable {
 
     private Long id;
     private String name;

--- a/src/main/java/com/flytrap/rssreader/domain/member/OauthInfo.java
+++ b/src/main/java/com/flytrap/rssreader/domain/member/OauthInfo.java
@@ -1,0 +1,13 @@
+package com.flytrap.rssreader.domain.member;
+
+import java.io.Serializable;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+class OauthInfo implements Serializable {
+
+    private Long oauthPk;
+    private OauthServer oauthServer;
+}

--- a/src/main/java/com/flytrap/rssreader/domain/member/OauthServer.java
+++ b/src/main/java/com/flytrap/rssreader/domain/member/OauthServer.java
@@ -1,0 +1,5 @@
+package com.flytrap.rssreader.domain.member;
+
+public enum OauthServer {
+    GITHUB;
+}

--- a/src/main/java/com/flytrap/rssreader/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/flytrap/rssreader/exception/GlobalExceptionHandler.java
@@ -1,0 +1,24 @@
+package com.flytrap.rssreader.exception;
+
+import java.util.NoSuchElementException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    public void handleException(NoSuchElementException e) {
+        e.printStackTrace();
+        log.error(e.getMessage());
+    }
+
+    @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+    public void handleException(Exception e) {
+        e.printStackTrace();
+        log.error(e.getMessage());
+    }
+}

--- a/src/main/java/com/flytrap/rssreader/exception/NoSuchDomainException.java
+++ b/src/main/java/com/flytrap/rssreader/exception/NoSuchDomainException.java
@@ -1,0 +1,11 @@
+package com.flytrap.rssreader.exception;
+
+import com.flytrap.rssreader.global.model.DefaultDomain;
+import java.util.NoSuchElementException;
+
+public class NoSuchDomainException extends NoSuchElementException {
+
+    public NoSuchDomainException(DefaultDomain domain) {
+        super("No such domain: " + domain.getDomainCode());
+    }
+}

--- a/src/main/java/com/flytrap/rssreader/global/config/PropertiesScanConfig.java
+++ b/src/main/java/com/flytrap/rssreader/global/config/PropertiesScanConfig.java
@@ -1,4 +1,4 @@
-package com.flytrap.rssreader.config;
+package com.flytrap.rssreader.global.config;
 
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
 import org.springframework.context.annotation.Configuration;

--- a/src/main/java/com/flytrap/rssreader/global/config/WebClientConfig.java
+++ b/src/main/java/com/flytrap/rssreader/global/config/WebClientConfig.java
@@ -1,4 +1,4 @@
-package com.flytrap.rssreader.config;
+package com.flytrap.rssreader.global.config;
 
 import com.flytrap.rssreader.infrastructure.properties.OauthProperties;
 import io.netty.channel.ChannelOption;

--- a/src/main/java/com/flytrap/rssreader/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/flytrap/rssreader/global/exception/GlobalExceptionHandler.java
@@ -1,4 +1,4 @@
-package com.flytrap.rssreader.exception;
+package com.flytrap.rssreader.global.exception;
 
 import java.util.NoSuchElementException;
 import lombok.extern.slf4j.Slf4j;

--- a/src/main/java/com/flytrap/rssreader/global/exception/NoSuchDomainException.java
+++ b/src/main/java/com/flytrap/rssreader/global/exception/NoSuchDomainException.java
@@ -1,4 +1,4 @@
-package com.flytrap.rssreader.exception;
+package com.flytrap.rssreader.global.exception;
 
 import com.flytrap.rssreader.global.model.DefaultDomain;
 import java.util.NoSuchElementException;

--- a/src/main/java/com/flytrap/rssreader/global/exception/NoSuchDomainException.java
+++ b/src/main/java/com/flytrap/rssreader/global/exception/NoSuchDomainException.java
@@ -6,6 +6,6 @@ import java.util.NoSuchElementException;
 public class NoSuchDomainException extends NoSuchElementException {
 
     public NoSuchDomainException(DefaultDomain domain) {
-        super("No such domain: " + domain.getDomainCode());
+        super(String.format("No such domain = " + domain.getDomainCodeWithId()));
     }
 }

--- a/src/main/java/com/flytrap/rssreader/global/model/DefaultDomain.java
+++ b/src/main/java/com/flytrap/rssreader/global/model/DefaultDomain.java
@@ -1,0 +1,10 @@
+package com.flytrap.rssreader.global.model;
+
+import java.io.Serializable;
+
+public abstract class DefaultDomain implements Serializable {
+
+    public String getDomainCode() {
+        return this.getClass().getAnnotation(Domain.class).name();
+    }
+}

--- a/src/main/java/com/flytrap/rssreader/global/model/DefaultDomain.java
+++ b/src/main/java/com/flytrap/rssreader/global/model/DefaultDomain.java
@@ -4,7 +4,14 @@ import java.io.Serializable;
 
 public abstract class DefaultDomain implements Serializable {
 
+    public abstract Long getId();
+
     public String getDomainCode() {
         return this.getClass().getAnnotation(Domain.class).name();
     }
+
+    public String getDomainCodeWithId() {
+        return String.format("%s_%d", this.getDomainCode(), this.getId());
+    }
+
 }

--- a/src/main/java/com/flytrap/rssreader/global/model/Domain.java
+++ b/src/main/java/com/flytrap/rssreader/global/model/Domain.java
@@ -1,0 +1,20 @@
+package com.flytrap.rssreader.global.model;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+@Documented
+@Target({ElementType.TYPE})
+@Retention(java.lang.annotation.RetentionPolicy.RUNTIME)
+public @interface Domain {
+
+    enum Type {
+        DOMAIN,
+        SUBDOMAIN
+    }
+
+    Type type() default Type.DOMAIN;
+    String name();
+}

--- a/src/main/java/com/flytrap/rssreader/global/model/Domain.java
+++ b/src/main/java/com/flytrap/rssreader/global/model/Domain.java
@@ -10,11 +10,5 @@ import java.lang.annotation.Target;
 @Retention(java.lang.annotation.RetentionPolicy.RUNTIME)
 public @interface Domain {
 
-    enum Type {
-        DOMAIN,
-        SUBDOMAIN
-    }
-
-    Type type() default Type.DOMAIN;
     String name();
 }

--- a/src/main/java/com/flytrap/rssreader/infrastructure/api/dto/UserResource.java
+++ b/src/main/java/com/flytrap/rssreader/infrastructure/api/dto/UserResource.java
@@ -2,7 +2,7 @@ package com.flytrap.rssreader.infrastructure.api.dto;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.flytrap.rssreader.domain.member.Member;
-import com.flytrap.rssreader.infrastructure.entity.member.OauthServer;
+import com.flytrap.rssreader.domain.member.OauthServer;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;

--- a/src/main/java/com/flytrap/rssreader/infrastructure/entity/member/MemberEntity.java
+++ b/src/main/java/com/flytrap/rssreader/infrastructure/entity/member/MemberEntity.java
@@ -1,6 +1,7 @@
 package com.flytrap.rssreader.infrastructure.entity.member;
 
 import com.flytrap.rssreader.domain.member.Member;
+import com.flytrap.rssreader.domain.member.OauthServer;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EntityListeners;

--- a/src/main/java/com/flytrap/rssreader/infrastructure/entity/member/OauthServer.java
+++ b/src/main/java/com/flytrap/rssreader/infrastructure/entity/member/OauthServer.java
@@ -1,5 +1,0 @@
-package com.flytrap.rssreader.infrastructure.entity.member;
-
-public enum OauthServer {
-    GITHUB;
-}

--- a/src/main/java/com/flytrap/rssreader/infrastructure/repository/MemberEntityJpaRepository.java
+++ b/src/main/java/com/flytrap/rssreader/infrastructure/repository/MemberEntityJpaRepository.java
@@ -1,9 +1,14 @@
 package com.flytrap.rssreader.infrastructure.repository;
 
 import com.flytrap.rssreader.infrastructure.entity.member.MemberEntity;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface MemberEntityJpaRepository extends JpaRepository<MemberEntity, Long> {
+
     Optional<MemberEntity> findByOauthPk(long oauthPk);
+
+    List<MemberEntity> findAllByName(String name);
+
 }

--- a/src/main/java/com/flytrap/rssreader/presentation/controller/MemberController.java
+++ b/src/main/java/com/flytrap/rssreader/presentation/controller/MemberController.java
@@ -1,18 +1,31 @@
 package com.flytrap.rssreader.presentation.controller;
 
+import com.flytrap.rssreader.domain.member.Member;
 import com.flytrap.rssreader.global.model.ApplicationResponse;
+import com.flytrap.rssreader.presentation.dto.MemberSummary;
+import com.flytrap.rssreader.presentation.dto.NameSearch;
+import com.flytrap.rssreader.presentation.dto.NameSearch.Result;
+import com.flytrap.rssreader.service.MemberService;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
+@RequiredArgsConstructor
 @RequestMapping("/api/members")
 public class MemberController {
 
-    @GetMapping
-    public ApplicationResponse<Object> searchMemberByName(String name) {
+    private final MemberService memberService;
 
-        return new ApplicationResponse<>(null);
+    @GetMapping
+    public ApplicationResponse<NameSearch.Result> searchMemberByName(NameSearch nameSearch) {
+        List<Member> results = memberService.findByName(nameSearch.name());
+
+        List<MemberSummary> memberSummaries = results.stream().map(MemberSummary::from).toList();
+        return new ApplicationResponse<>(new Result(memberSummaries));
     }
 
 }

--- a/src/main/java/com/flytrap/rssreader/presentation/dto/MemberSummary.java
+++ b/src/main/java/com/flytrap/rssreader/presentation/dto/MemberSummary.java
@@ -1,0 +1,17 @@
+package com.flytrap.rssreader.presentation.dto;
+
+import com.flytrap.rssreader.domain.member.Member;
+
+public record MemberSummary(Long id,
+                            String name,
+                            String profile) {
+
+    public static MemberSummary from(Member member) {
+        return new MemberSummary(
+                member.getId(),
+                member.getName(),
+                member.getProfile()
+        );
+    }
+
+}

--- a/src/main/java/com/flytrap/rssreader/presentation/dto/NameSearch.java
+++ b/src/main/java/com/flytrap/rssreader/presentation/dto/NameSearch.java
@@ -1,7 +1,9 @@
 package com.flytrap.rssreader.presentation.dto;
 
+import java.util.List;
+
 public record NameSearch(String name) {
 
-    public record Result(MemberSummary memberSummary) {
+    public record Result(List<MemberSummary> memberSummary) {
     }
 }

--- a/src/main/java/com/flytrap/rssreader/presentation/dto/NameSearch.java
+++ b/src/main/java/com/flytrap/rssreader/presentation/dto/NameSearch.java
@@ -1,0 +1,7 @@
+package com.flytrap.rssreader.presentation.dto;
+
+public record NameSearch(String name) {
+
+    public record Result(MemberSummary memberSummary) {
+    }
+}

--- a/src/main/java/com/flytrap/rssreader/service/MemberService.java
+++ b/src/main/java/com/flytrap/rssreader/service/MemberService.java
@@ -5,6 +5,7 @@ import com.flytrap.rssreader.infrastructure.api.dto.UserResource;
 import com.flytrap.rssreader.infrastructure.entity.member.MemberEntity;
 import com.flytrap.rssreader.infrastructure.repository.MemberEntityJpaRepository;
 import jakarta.transaction.Transactional;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -15,9 +16,10 @@ public class MemberService {
     private final MemberEntityJpaRepository memberEntityJpaRepository;
 
     /**
+     * Member 정보를 반환합니다.
      * User resource가 Member 테이블에 존재하지 않으면 새로 가입 후 Member 정보를 반환합니다.
      * @param userResource
-     * @return
+     * @return Member domain
      */
     @Transactional
     public Member loginMember(UserResource userResource) {
@@ -27,7 +29,23 @@ public class MemberService {
             .toDomain();
     }
 
+    /**
+     * Member 테이블에 새로운 회원을 가입시킵니다.
+     * @param member
+     * @return
+     */
     private MemberEntity joinMember(Member member) {
         return memberEntityJpaRepository.save(MemberEntity.from(member));
+    }
+
+    /**
+     * 이름으로 회원을 검색합니다.
+     * @param name
+     * @return Member domain list
+     */
+    public List<Member> findByName(String name) {
+        return memberEntityJpaRepository.findAllByName(name).stream()
+                .map(MemberEntity::toDomain)
+                .toList();
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -3,3 +3,5 @@ spring:
     active: local
     group:
         local: [ local, oauth ] # localhost
+  jpa:
+    open-in-view: false

--- a/src/test/java/com/flytrap/rssreader/service/AuthServiceTest.java
+++ b/src/test/java/com/flytrap/rssreader/service/AuthServiceTest.java
@@ -1,12 +1,16 @@
 package com.flytrap.rssreader.service;
 
-import static org.mockito.BDDMockito.*;
+import static org.mockito.BDDMockito.any;
+import static org.mockito.BDDMockito.anyString;
+import static org.mockito.BDDMockito.times;
+import static org.mockito.BDDMockito.verify;
+import static org.mockito.BDDMockito.when;
 
 import com.flytrap.rssreader.domain.member.Member;
+import com.flytrap.rssreader.domain.member.OauthServer;
 import com.flytrap.rssreader.infrastructure.api.AuthProvider;
 import com.flytrap.rssreader.infrastructure.api.dto.AccessToken;
 import com.flytrap.rssreader.infrastructure.api.dto.UserResource;
-import com.flytrap.rssreader.infrastructure.entity.member.OauthServer;
 import com.flytrap.rssreader.presentation.dto.Login;
 import jakarta.servlet.http.HttpSession;
 import org.assertj.core.api.SoftAssertions;
@@ -38,20 +42,22 @@ class AuthServiceTest {
     @BeforeEach
     void init() {
         when(authProvider.requestAccessToken(anyString()))
-            .thenReturn(Mono.just(new AccessToken("test_access_token", "Bearer")));
+                .thenReturn(Mono.just(new AccessToken("test_access_token", "Bearer")));
         when(authProvider.requestUserResource(any()))
-            .thenReturn(Mono.just(UserResource.builder().id(1L).email("test@gmail.com").login("login").avatarUrl("img.jpg").build()));
+                .thenReturn(Mono.just(
+                        UserResource.builder().id(1L).email("test@gmail.com").login("login")
+                                .avatarUrl("img.jpg").build()));
         when(memberService.loginMember(any()))
-            .thenReturn(
-                Member.builder()
-                    .id(1L)
-                    .name("테스트")
-                    .email("test@gmail.com")
-                    .profile("img.jpg")
-                    .oauthPk(11L)
-                    .oauthServer(OauthServer.GITHUB)
-                    .build()
-            );
+                .thenReturn(
+                        Member.builder()
+                                .id(1L)
+                                .name("테스트")
+                                .email("test@gmail.com")
+                                .profile("img.jpg")
+                                .oauthPk(11L)
+                                .oauthServer(OauthServer.GITHUB)
+                                .build()
+                );
     }
 
     @Test

--- a/src/test/java/com/flytrap/rssreader/service/MemberServiceTest.java
+++ b/src/test/java/com/flytrap/rssreader/service/MemberServiceTest.java
@@ -1,11 +1,14 @@
 package com.flytrap.rssreader.service;
 
-import static org.mockito.BDDMockito.*;
+import static org.mockito.BDDMockito.any;
+import static org.mockito.BDDMockito.times;
+import static org.mockito.BDDMockito.verify;
+import static org.mockito.BDDMockito.when;
 
 import com.flytrap.rssreader.domain.member.Member;
+import com.flytrap.rssreader.domain.member.OauthServer;
 import com.flytrap.rssreader.infrastructure.api.dto.UserResource;
 import com.flytrap.rssreader.infrastructure.entity.member.MemberEntity;
-import com.flytrap.rssreader.infrastructure.entity.member.OauthServer;
 import com.flytrap.rssreader.infrastructure.repository.MemberEntityJpaRepository;
 import java.util.Optional;
 import org.assertj.core.api.SoftAssertions;
@@ -31,26 +34,26 @@ class MemberServiceTest {
     void loginMemberWithExistMember() {
         // given
         when(memberEntityJpaRepository.findByOauthPk(1L))
-            .thenReturn(Optional.of(
-                MemberEntity.builder()
-                    .id(1L)
-                    .email("test@gmail.com")
-                    .name("name")
-                    .profile("avatarUrl.jpg")
-                    .oauthPk(1L)
-                    .oauthServer(OauthServer.GITHUB)
-                    .build()
-            ));
+                .thenReturn(Optional.of(
+                        MemberEntity.builder()
+                                .id(1L)
+                                .email("test@gmail.com")
+                                .name("name")
+                                .profile("avatarUrl.jpg")
+                                .oauthPk(1L)
+                                .oauthServer(OauthServer.GITHUB)
+                                .build()
+                ));
 
         // when
         Member existMember
-            = memberService.loginMember(
-            UserResource.builder()
-                .id(1L)
-                .email("test@gmail.com")
-                .login("login")
-                .avatarUrl("avatarUrl.jpg")
-                .build());
+                = memberService.loginMember(
+                UserResource.builder()
+                        .id(1L)
+                        .email("test@gmail.com")
+                        .login("login")
+                        .avatarUrl("avatarUrl.jpg")
+                        .build());
 
         // then
         SoftAssertions.assertSoftly(softAssertions -> {
@@ -66,29 +69,29 @@ class MemberServiceTest {
     void loginMemberWithNotExistMember() {
         //given
         when(memberEntityJpaRepository.findByOauthPk(1L))
-            .thenReturn(Optional.empty());
+                .thenReturn(Optional.empty());
 
         when(memberEntityJpaRepository.save(any()))
-            .thenReturn(
-                MemberEntity.builder()
-                    .id(1L)
-                    .email("test@gmail.com")
-                    .name("name")
-                    .profile("avatarUrl.jpg")
-                    .oauthPk(1L)
-                    .oauthServer(OauthServer.GITHUB)
-                    .build()
-            );
+                .thenReturn(
+                        MemberEntity.builder()
+                                .id(1L)
+                                .email("test@gmail.com")
+                                .name("name")
+                                .profile("avatarUrl.jpg")
+                                .oauthPk(1L)
+                                .oauthServer(OauthServer.GITHUB)
+                                .build()
+                );
 
         // when
         Member newMember
-            = memberService.loginMember(
-            UserResource.builder()
-                .id(1L)
-                .email("test@gmail.com")
-                .login("login")
-                .avatarUrl("avatarUrl.jpg")
-                .build());
+                = memberService.loginMember(
+                UserResource.builder()
+                        .id(1L)
+                        .email("test@gmail.com")
+                        .login("login")
+                        .avatarUrl("avatarUrl.jpg")
+                        .build());
 
         // then
         SoftAssertions.assertSoftly(softAssertions -> {


### PR DESCRIPTION
## 🔑 Key Changes
- 회원 이름으로 검색을 구현하였습니다.
- 도메인 공통 예외처리를 위해 global exception handler와 custom exception, annotation을 구현하였습니다.

## 👩‍💻 To Reviewers
- 공통 예외처리 로직을 한번 확인해주세요. 좋은 방식이 있다면 말씀해주세요.

### 공통 예외처리 로직 제안
- 어노테이션과 인터페이스 기반의 domain 코드를 만들고 이를 적용시켜 에러코드에 활용하는 방안

#### 장점

1. 에러코드를 위한 Enum등을 만들지 않아도되어 코드가 줄어들 수 있음
2. 도메인에 대한 메타정보를 어노테이션으로 한번에 관리할 수 있음

#### 단점

1. 도메인 만들때마다 어노테이션과 인터페이스를 둘다 적용시켜줘야함…..
2. DefaultDomain을 인터페이스로 기능을 추가하고 싶었는데, 예외발생으로 피치못하게 `extends` 로 구현함.

함께 시그니처(파일이름)도 적절한지 얘기해봤으면 좋겠습니다.

## Related to
- Close #22 
- #16 
