### PR TITLE
PR #32 리뷰반영 - 게시글 수집 작업을 비동기 작업으로 변경

### DIFF
--- a/src/main/java/com/flytrap/rssreader/RssReaderApplication.java
+++ b/src/main/java/com/flytrap/rssreader/RssReaderApplication.java
@@ -3,8 +3,10 @@ package com.flytrap.rssreader;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
+@EnableAsync
 @EnableScheduling
 @EnableJpaAuditing
 @SpringBootApplication

--- a/src/main/java/com/flytrap/rssreader/service/PostCollectService.java
+++ b/src/main/java/com/flytrap/rssreader/service/PostCollectService.java
@@ -11,9 +11,9 @@ import java.util.List;
 import java.util.Map;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.task.TaskExecutor;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 @Slf4j
 @AllArgsConstructor
@@ -26,15 +26,27 @@ public class PostCollectService {
     private final SubscribeEntityJpaRepository subscribeEntityJpaRepository;
     private final PostEntityJpaRepository postEntityJpaRepository;
 
-    @Transactional
+    private final TaskExecutor taskExecutor;
+
     @Scheduled(fixedDelay = TEN_MINUTE)
     public void collectPosts() {
         List<SubscribeEntity> subscribes = subscribeEntityJpaRepository.findAll();
 
         for (SubscribeEntity subscribe : subscribes) {
+            processPostCollectionAsync(subscribe);
+        }
+    }
+
+    /**
+     * 구독한 블로그의 RSS에서 게시글들을 읽어서 DB에 저장한다.<br>
+     * 비동기 처리되어 있으며 블로그 하나당 하나의 스레드에서 동작한다.
+     * @param subscribe 구독한 블로그
+     */
+    private void processPostCollectionAsync(SubscribeEntity subscribe) {
+        taskExecutor.execute(() -> {
             List<RssItemResource> itemResources = postParser.parseRssDocuments(subscribe.getUrl());
             savePosts(itemResources, subscribe);
-        }
+        });
     }
 
     private void savePosts(List<RssItemResource> itemResources, SubscribeEntity subscribe) {

--- a/src/main/resources/db/data.sql
+++ b/src/main/resources/db/data.sql
@@ -3,4 +3,5 @@ INSERT INTO `member`(name, email, profile, oauth_pk, oauth_server, created_at)
 VALUES ('test', 'test@test.com', 'profile.png', '11111', 'GITHUB', '2023-11-16');
 
 INSERT INTO `rss_subscribe`(description, url, member_id, platform)
-VALUES ('description', 'https://v2.velog.io/rss/jinny-l', '1', 'VELOG');
+VALUES ('description', 'https://v2.velog.io/rss/jinny-l', '1', 'VELOG'),
+       ('description', 'https://v2.velog.io/rss/ape', '1', 'VELOG');


### PR DESCRIPTION
## 🔑 Key Changes
- 게시글 수집 작업을 비동기 작업으로 변경

## 👩‍💻 To Reviewers
- 비동기 처리호 변경하면서 이 작업이 트랜잭션으로 안 묶어도 되지 않을까 싶어서 트랜잭션 뺐어요.
    - 스케쥴이 한번 수행 될 때 블로그 10개 저장 중에 하나 실패해도 나머지 9개는 정상적으로 저장되도록 하는게 더 적중율이 높을 것 같아요

### 동작 사진
<img width="487" alt="SCR-20231118-drgo" src="https://github.com/Flytrap-Ware/RSS-Reader/assets/86359180/b5f88a09-1f0c-4452-967f-258691fc0a5d">

## Related to
- #32
- #36 
- Closes #45 